### PR TITLE
Extend `smtp-server`'s API to enable implementation of LMTP servers as well

### DIFF
--- a/kannader-config-forwarder/src/main.rs
+++ b/kannader-config-forwarder/src/main.rs
@@ -117,18 +117,22 @@ impl kannader_config::ServerConfig for ServerConfig {
 
     fn filter_hello(
         cfg: &Config,
-        is_ehlo: bool,
+        is_extended: bool,
         hostname: Hostname,
         conn_meta: &mut server::ConnMeta,
     ) -> server::SerializableDecision<server::HelloInfo> {
         let mut cm = conn_meta.clone();
         cm.hello = Some(server::HelloInfo {
-            is_ehlo,
+            is_extended,
             hostname: hostname.clone(),
         });
         server::SerializableDecision::Accept {
-            reply: reply::okay_hello(is_ehlo, "localhost", "", Self::can_do_tls(cfg, cm)).convert(),
-            res: server::HelloInfo { is_ehlo, hostname },
+            reply: reply::okay_hello(is_extended, "localhost", "", Self::can_do_tls(cfg, cm))
+                .convert(),
+            res: server::HelloInfo {
+                is_extended,
+                hostname,
+            },
         }
     }
 

--- a/kannader-config-macros/src/lib.rs
+++ b/kannader-config-macros/src/lib.rs
@@ -857,7 +857,7 @@ static SERVER_CONFIG: fn() -> Communicator = communicator! {
 
         fn filter_hello(
             &self,
-            is_ehlo: () bool,
+            is_extended: () bool,
             hostname: () smtp_message::Hostname,
             conn_meta: (&mut) smtp_server_types::ConnectionMetadata<Vec<u8>>,
         ) -> (smtp_server_types::SerializableDecision<smtp_server_types::HelloInfo>) ;
@@ -868,7 +868,7 @@ static SERVER_CONFIG: fn() -> Communicator = communicator! {
         ) -> (bool)
         {
             !conn_meta.is_encrypted &&
-                conn_meta.hello.as_ref().map(|h| h.is_ehlo).unwrap_or(false)
+                conn_meta.hello.as_ref().map(|h| h.is_extended).unwrap_or(false)
         }
 
         fn new_mail(

--- a/kannader/src/server_config.rs
+++ b/kannader/src/server_config.rs
@@ -162,11 +162,11 @@ where
     /// Also, note that there is no timeout applied here, so the implementation
     /// of this function is responsible for making sure that the client does not
     /// just stop sending anything to DOS the system.
-    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
-        &'cfg self,
-        stream: &mut smtp_message::EscapedDataReader<'contents, R>,
+    async fn handle_mail<'resp, R>(
+        &'resp self,
+        stream: &mut smtp_message::EscapedDataReader<'_, R>,
         meta: MailMeta,
-        _conn_meta: &'connmeta mut ConnMeta,
+        _conn_meta: &'resp mut ConnMeta,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/kannader/src/server_config.rs
+++ b/kannader/src/server_config.rs
@@ -59,10 +59,9 @@ impl<T> smtp_server::Config for ServerConfig<T>
 where
     T: smtp_queue::Transport<Meta>,
 {
-    type Protocol = smtp_server::protocol::Smtp;
-
     type ConnectionUserMeta = Vec<u8>;
     type MailUserMeta = Vec<u8>;
+    type Protocol = smtp_server::protocol::Smtp;
 
     fn hostname(&self, _: &ConnMeta) -> &str {
         unimplemented!()
@@ -82,11 +81,11 @@ where
 
     async fn filter_hello(
         &self,
-        is_ehlo: bool,
+        is_extended: bool,
         hostname: Hostname,
         conn_meta: &mut ConnMeta,
     ) -> Decision<HelloInfo> {
-        run_hook!(filter_hello(is_ehlo, hostname, conn_meta))
+        run_hook!(filter_hello(is_extended, hostname, conn_meta))
     }
 
     fn can_do_tls(&self, conn_meta: &ConnMeta) -> bool {

--- a/kannader/src/server_config.rs
+++ b/kannader/src/server_config.rs
@@ -59,6 +59,8 @@ impl<T> smtp_server::Config for ServerConfig<T>
 where
     T: smtp_queue::Transport<Meta>,
 {
+    type Protocol = smtp_server::protocol::Smtp;
+
     type ConnectionUserMeta = Vec<u8>;
     type MailUserMeta = Vec<u8>;
 
@@ -161,11 +163,11 @@ where
     /// Also, note that there is no timeout applied here, so the implementation
     /// of this function is responsible for making sure that the client does not
     /// just stop sending anything to DOS the system.
-    async fn handle_mail<'a, R>(
-        &self,
-        stream: &mut smtp_message::EscapedDataReader<'a, R>,
+    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
+        &'cfg self,
+        stream: &mut smtp_message::EscapedDataReader<'contents, R>,
         meta: MailMeta,
-        _conn_meta: &mut ConnMeta,
+        _conn_meta: &'connmeta mut ConnMeta,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/smtp-server-types/src/lib.rs
+++ b/smtp-server-types/src/lib.rs
@@ -61,7 +61,7 @@ pub struct MailMetadata<U> {
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct HelloInfo {
-    /// is_extended: whether we are running Extended SMTP (ESMTP) or LMTP,
+    /// Whether we are running Extended SMTP (ESMTP) or LMTP,
     /// rather than plain SMTP
     pub is_extended: bool,
     pub hostname: Hostname,

--- a/smtp-server-types/src/lib.rs
+++ b/smtp-server-types/src/lib.rs
@@ -61,7 +61,9 @@ pub struct MailMetadata<U> {
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct HelloInfo {
-    pub is_ehlo: bool,
+    /// is_extended: whether we are running Extended SMTP (ESMTP) or LMTP,
+    /// rather than plain SMTP
+    pub is_extended: bool,
     pub hostname: Hostname,
 }
 

--- a/smtp-server-types/src/reply.rs
+++ b/smtp-server-types/src/reply.rs
@@ -11,14 +11,19 @@ pub fn welcome_banner(hostname: &str, banner: &str) -> Reply {
 
 /// Usual value for returning “Okay” from `filter_hello`
 #[inline]
-pub fn okay_hello(is_ehlo: bool, local_hostname: &str, banner: &str, can_do_tls: bool) -> Reply {
+pub fn okay_hello(
+    is_extended: bool,
+    local_hostname: &str,
+    banner: &str,
+    can_do_tls: bool,
+) -> Reply {
     let mut built_banner = String::from(local_hostname);
     if !banner.is_empty() {
         built_banner += " ";
         built_banner += banner;
     }
     let mut text = vec![MaybeUtf8::Utf8(built_banner)];
-    if is_ehlo {
+    if is_extended {
         text.push(MaybeUtf8::Ascii("8BITMIME".into()));
         text.push(MaybeUtf8::Ascii("ENHANCEDSTATUSCODES".into()));
         text.push(MaybeUtf8::Ascii("PIPELINING".into()));

--- a/smtp-server/examples/simple_stdio.rs
+++ b/smtp-server/examples/simple_stdio.rs
@@ -91,12 +91,9 @@ impl smtp_server::Config for SimpleConfig {
         reader: &mut EscapedDataReader<'contents, R>,
         _meta: MailMetadata<Self::MailUserMeta>,
         _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
-    ) -> <Self::Protocol as smtp_server::Protocol<'resp>>::HandleMailReturnType
+    ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,
-        'cfg: 'resp,
-        'connmeta: 'resp,
-        Self: 'resp,
     {
         let mut text = Vec::new();
         if reader.read_to_end(&mut text).await.is_err() {

--- a/smtp-server/examples/simple_stdio.rs
+++ b/smtp-server/examples/simple_stdio.rs
@@ -86,11 +86,11 @@ impl smtp_server::Config for SimpleConfig {
         }
     }
 
-    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
-        &'cfg self,
-        reader: &mut EscapedDataReader<'contents, R>,
-        _meta: MailMetadata<Self::MailUserMeta>,
-        _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
+    async fn handle_mail<'resp, R>(
+        &'resp self,
+        reader: &mut EscapedDataReader<'_, R>,
+        _meta: MailMetadata<()>,
+        _conn_meta: &'resp mut ConnectionMetadata<()>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/smtp-server/examples/simple_stdio.rs
+++ b/smtp-server/examples/simple_stdio.rs
@@ -89,7 +89,7 @@ impl smtp_server::Config for SimpleConfig {
     async fn handle_mail<'resp, R>(
         &'resp self,
         reader: &mut EscapedDataReader<'_, R>,
-        _meta: MailMetadata<()>,
+        _mail: MailMetadata<()>,
         _conn_meta: &'resp mut ConnectionMetadata<()>,
     ) -> Decision<()>
     where

--- a/smtp-server/fuzz/fuzz_targets/fuzz_interact.rs
+++ b/smtp-server/fuzz/fuzz_targets/fuzz_interact.rs
@@ -100,11 +100,11 @@ impl smtp_server::Config for FuzzConfig {
     }
 
     #[allow(clippy::needless_lifetimes)] // false-positive
-    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
-        &'cfg self,
-        reader: &mut EscapedDataReader<'contents, R>,
+    async fn handle_mail<'resp, R>(
+        &'resp self,
+        reader: &mut EscapedDataReader<'_, R>,
         mail: MailMetadata<()>,
-        _conn_meta: &'connmeta mut ConnectionMetadata<()>,
+        _conn_meta: &'resp mut ConnectionMetadata<()>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/smtp-server/fuzz/fuzz_targets/fuzz_interact.rs
+++ b/smtp-server/fuzz/fuzz_targets/fuzz_interact.rs
@@ -103,8 +103,8 @@ impl smtp_server::Config for FuzzConfig {
     async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
         &'cfg self,
         reader: &mut EscapedDataReader<'contents, R>,
-        _meta: MailMetadata<Self::MailUserMeta>,
-        _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
+        mail: MailMetadata<()>,
+        _conn_meta: &'connmeta mut ConnectionMetadata<()>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/smtp-server/fuzz/fuzz_targets/fuzz_interact.rs
+++ b/smtp-server/fuzz/fuzz_targets/fuzz_interact.rs
@@ -22,6 +22,7 @@ struct FuzzConfig;
 impl smtp_server::Config for FuzzConfig {
     type ConnectionUserMeta = ();
     type MailUserMeta = ();
+    type Protocol = smtp_server::protocol::Smtp;
 
     fn hostname(&self, _conn_meta: &ConnectionMetadata<()>) -> &str {
         "test.example.org"
@@ -99,11 +100,11 @@ impl smtp_server::Config for FuzzConfig {
     }
 
     #[allow(clippy::needless_lifetimes)] // false-positive
-    async fn handle_mail<'a, R>(
-        &self,
-        reader: &mut EscapedDataReader<'a, R>,
-        mail: MailMetadata<()>,
-        _conn_meta: &mut ConnectionMetadata<()>,
+    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
+        &'cfg self,
+        reader: &mut EscapedDataReader<'contents, R>,
+        _meta: MailMetadata<Self::MailUserMeta>,
+        _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/smtp-server/src/lib.rs
+++ b/smtp-server/src/lib.rs
@@ -144,9 +144,6 @@ pub trait Config: Send + Sync {
         }
     }
 
-    // TODO: we might be able to remove the Box type in the return value when
-    // Rust gains GATs (generic associated types) and TAIT (type Alias = impl
-    // Trait) is implemented
     /// `handle_mail` is an async function that returns either a single decision
     /// in the case of the SMTP protocol, or an async stream of decisions in the
     /// case of the LMTP protocol.

--- a/smtp-server/src/lib.rs
+++ b/smtp-server/src/lib.rs
@@ -699,7 +699,7 @@ where
                                     }
                                     simple_handler!(decision);
                                 }
-                                assert_eq!(n_decisions, expected_n_decisions);
+                                assert_eq!(n_decisions, expected_n_decisions, "got {} decisions in handle_mail return, expected {}", n_decisions, expected_n_decisions);
                             } else {
                                 // handle_mail did not call complete, let's read until the end and
                                 // then return an error

--- a/smtp-server/src/lib.rs
+++ b/smtp-server/src/lib.rs
@@ -895,12 +895,9 @@ mod tests {
             reader: &mut EscapedDataReader<'contents, R>,
             meta: MailMetadata<Self::MailUserMeta>,
             _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
-        ) -> <Self::Protocol as Protocol<'resp>>::HandleMailReturnType
+        ) -> Decision<()>
         where
             R: Send + Unpin + AsyncRead,
-            'cfg: 'resp,
-            'connmeta: 'resp,
-            Self: 'resp,
         {
             let mut mail_text = Vec::new();
             let res = reader.read_to_end(&mut mail_text).await;

--- a/smtp-server/src/lib.rs
+++ b/smtp-server/src/lib.rs
@@ -577,7 +577,9 @@ where
                     Command::Lhlo { hostname } => (ProtocolName::Lmtp, true, hostname),
                     _ => unreachable!(),
                 };
-                if cmd_proto == <Cfg::Protocol as Protocol<'static>>::PROTOCOL {
+                if cmd_proto != <Cfg::Protocol as Protocol<'static>>::PROTOCOL {
+                    send_reply!(io, cfg.command_unrecognized(&mut conn_meta)).await?;
+                } else {
                     match conn_meta.hello {
                         Some(_) => {
                             send_reply!(io, cfg.already_did_hello(&mut conn_meta)).await?;
@@ -591,8 +593,6 @@ where
                             }
                         },
                     }
-                } else {
-                    send_reply!(io, cfg.command_unrecognized(&mut conn_meta)).await?;
                 }
             }
 

--- a/smtp-server/src/lib.rs
+++ b/smtp-server/src/lib.rs
@@ -695,7 +695,7 @@ where
                                 while let Some(decision) = decision_stream.next().await {
                                     n_decisions += 1;
                                     if n_decisions > expected_n_decisions {
-                                        break;
+                                        panic!("got more decisions in handle_mail return than the expected {}", expected_n_decisions);
                                     }
                                     simple_handler!(decision);
                                 }

--- a/smtp-server/src/protocol.rs
+++ b/smtp-server/src/protocol.rs
@@ -13,8 +13,12 @@ pub enum ProtocolName {
 pub trait Protocol<'resp>: private::Sealed {
     const PROTOCOL: ProtocolName;
 
+    // TODO: when we have GATs, 'resp should be a parameter of HandleMailReturnType
+    // and not of the whole Protocol trait.
     type HandleMailReturnType;
 
+    // TODO: we might be able to remove the Box type here Rust gains GATs (generic
+    // associated types) and TAIT (type Alias = impl Trait) is implemented
     fn handle_mail_return_type_as_stream(
         _resp: Self::HandleMailReturnType,
     ) -> Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>>;
@@ -35,8 +39,7 @@ impl<'resp> Protocol<'resp> for Smtp {
 
 pub struct Lmtp;
 impl<'resp> Protocol<'resp> for Lmtp {
-    // TODO: we might be able to remove the Box type here Rust gains GATs (generic
-    // associated types) and TAIT (type Alias = impl Trait) is implemented
+    // TODO: same as above, GAT+TAIT might allow us to remove Box here
     type HandleMailReturnType = Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>>;
 
     const PROTOCOL: ProtocolName = ProtocolName::Lmtp;

--- a/smtp-server/src/protocol.rs
+++ b/smtp-server/src/protocol.rs
@@ -1,0 +1,53 @@
+use std::pin::Pin;
+
+use futures::StreamExt;
+
+use smtp_server_types::Decision;
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum ProtocolName {
+    Smtp,
+    Lmtp,
+}
+
+pub trait Protocol<'resp>: private::Sealed {
+    const PROTOCOL: ProtocolName;
+
+    type HandleMailReturnType;
+
+    fn handle_mail_return_type_as_stream(
+        _resp: Self::HandleMailReturnType,
+    ) -> Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>>;
+}
+
+pub struct Smtp;
+impl<'resp> Protocol<'resp> for Smtp {
+    type HandleMailReturnType = Decision<()>;
+
+    const PROTOCOL: ProtocolName = ProtocolName::Smtp;
+
+    fn handle_mail_return_type_as_stream(
+        resp: Self::HandleMailReturnType,
+    ) -> Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>> {
+        futures::stream::once(async move { resp }).boxed()
+    }
+}
+
+pub struct Lmtp;
+impl<'resp> Protocol<'resp> for Lmtp {
+    type HandleMailReturnType = Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>>;
+
+    const PROTOCOL: ProtocolName = ProtocolName::Lmtp;
+
+    fn handle_mail_return_type_as_stream(
+        resp: Self::HandleMailReturnType,
+    ) -> Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>> {
+        resp
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Smtp {}
+    impl Sealed for super::Lmtp {}
+}

--- a/smtp-server/src/protocol.rs
+++ b/smtp-server/src/protocol.rs
@@ -35,6 +35,8 @@ impl<'resp> Protocol<'resp> for Smtp {
 
 pub struct Lmtp;
 impl<'resp> Protocol<'resp> for Lmtp {
+    // TODO: we might be able to remove the Box type here Rust gains GATs (generic
+    // associated types) and TAIT (type Alias = impl Trait) is implemented
     type HandleMailReturnType = Pin<Box<dyn futures::Stream<Item = Decision<()>> + Send + 'resp>>;
 
     const PROTOCOL: ProtocolName = ProtocolName::Lmtp;

--- a/tests/integration/tests/tests.rs
+++ b/tests/integration/tests/tests.rs
@@ -109,11 +109,11 @@ impl smtp_server::Config for TestReceiverCfg {
         }
     }
 
-    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
-        &'cfg self,
-        reader: &mut EscapedDataReader<'contents, R>,
+    async fn handle_mail<'resp, R>(
+        &'resp self,
+        reader: &mut EscapedDataReader<'_, R>,
         meta: MailMetadata<()>,
-        _conn_meta: &'connmeta mut ConnectionMetadata<()>,
+        _conn_meta: &'resp mut ConnectionMetadata<()>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/tests/integration/tests/tests.rs
+++ b/tests/integration/tests/tests.rs
@@ -112,8 +112,8 @@ impl smtp_server::Config for TestReceiverCfg {
     async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
         &'cfg self,
         reader: &mut EscapedDataReader<'contents, R>,
-        _meta: MailMetadata<Self::MailUserMeta>,
-        _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
+        meta: MailMetadata<()>,
+        _conn_meta: &'connmeta mut ConnectionMetadata<()>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,

--- a/tests/integration/tests/tests.rs
+++ b/tests/integration/tests/tests.rs
@@ -60,6 +60,7 @@ impl TestReceiverCfg {
 impl smtp_server::Config for TestReceiverCfg {
     type ConnectionUserMeta = ();
     type MailUserMeta = ();
+    type Protocol = smtp_server::protocol::Smtp;
 
     fn hostname(&self, _conn_meta: &ConnectionMetadata<()>) -> &str {
         "receiver.example.org".into()
@@ -108,11 +109,11 @@ impl smtp_server::Config for TestReceiverCfg {
         }
     }
 
-    async fn handle_mail<'a, R>(
-        &self,
-        reader: &mut EscapedDataReader<'a, R>,
-        meta: MailMetadata<()>,
-        _conn_meta: &mut ConnectionMetadata<()>,
+    async fn handle_mail<'contents, 'cfg, 'connmeta, 'resp, R>(
+        &'cfg self,
+        reader: &mut EscapedDataReader<'contents, R>,
+        _meta: MailMetadata<Self::MailUserMeta>,
+        _conn_meta: &'connmeta mut ConnectionMetadata<Self::ConnectionUserMeta>,
     ) -> Decision<()>
     where
         R: Send + Unpin + AsyncRead,


### PR DESCRIPTION
This PR introduces the following changes:

- Add support for LMTP's `LHLO` message in `smtp-message`
- Add a `PROTOCOL` constant to the `smtp_server::Config` trait (it defaults to `Smtp`)
- Add a funciton `handle_mail_multi` to trait `smtp_server::Config` that can be implemented insteaad of `handle_mail` for LMTP server implementors that must be able to send back multiple responses

This patch does not change the API of `smtp_server::Config` for users that implement SMTP servers, in other words it should break no existing code.